### PR TITLE
Removed http

### DIFF
--- a/src/Chirp.Razor/Properties/launchSettings.json
+++ b/src/Chirp.Razor/Properties/launchSettings.json
@@ -8,15 +8,6 @@
     }
   },
   "profiles": {
-    "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "http://localhost:5273",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,


### PR DESCRIPTION
Removed http, so you are only able to open https only

if it doesn't work for you, you should run :
dotnet clean
dotnet dev-certs https --clean
dotnet dev-certs https --trust